### PR TITLE
One-liner for fermion arrows

### DIFF
--- a/server/feynman.sty
+++ b/server/feynman.sty
@@ -227,6 +227,9 @@
     \endgroup
 }
 
+% Oneliner fermion declaration
+\newcommand{\fermionArray}[1]{\@ifnextchar\bgroup{\fermionContinue{#1}}{ }}
+\newcommand{\fermionContinue}[2]{\fermion[]{#1}{#2}\@ifnextchar\bgroup{\fermionContinue{#2}}{ }}
 
 % dashed propagators
 \newcommand*{\dashed}[3][]{


### PR DESCRIPTION
Declare the `fermionArray` command which draws fermion arrows in sequence.